### PR TITLE
full width search input on mobile

### DIFF
--- a/src/containers/WrappedStats/styles.ts
+++ b/src/containers/WrappedStats/styles.ts
@@ -45,8 +45,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     }
   },
   searchBar: {
-    width: '100%',
-    maxWidth: 221,
+    width: 221,
     height: 32,
     padding: '7px 12px',
     borderRadius: 10,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2b1ff60f-2e8e-4f31-8da4-5e5e0f7bca5d)
