### PR TITLE
fix show price warnings

### DIFF
--- a/src/store/hooks/positionList/useTokenValues.ts
+++ b/src/store/hooks/positionList/useTokenValues.ts
@@ -64,7 +64,9 @@ export const useTokenValues = ({
     return {
       loading: false,
       value: totalValue,
-      priceWarning: tokenXPriceData.price === 0 || tokenYPriceData.price === 0
+      priceWarning:
+        (tokenXPriceData.price === 0 && tokenXLiquidity > 0) ||
+        (tokenYPriceData.price === 0 && tokenYLiquidity > 0)
     }
   }, [tokenXLiquidity, tokenYLiquidity, tokenXPriceData, tokenYPriceData, previousTokenValueInUsd])
 

--- a/src/store/hooks/userOverview/useAgregatedPositions.ts
+++ b/src/store/hooks/userOverview/useAgregatedPositions.ts
@@ -53,7 +53,8 @@ const calculateTokenValue = (
 const createPositionEntry = (
   position: TokenPosition,
   isTokenX: boolean,
-  value: number
+  value: number,
+  isPriceWarning: boolean
 ): TokenPositionEntry => {
   const token = isTokenX ? position.tokenX : position.tokenY
 
@@ -63,7 +64,7 @@ const createPositionEntry = (
     name: token.name,
     logo: token.logoURI,
     positionId: position.id,
-    isPriceWarning: false
+    isPriceWarning: isPriceWarning
   }
 }
 
@@ -85,7 +86,15 @@ const updateOrCreatePosition = (
     return positions
   }
 
-  return [...positions, createPositionEntry(position, isTokenX, value)]
+  return [
+    ...positions,
+    createPositionEntry(
+      position,
+      isTokenX,
+      value,
+      !prices?.[token.assetAddress.toString()] && +amountBN.toString() > 0
+    )
+  ]
 }
 
 export const useAgregatedPositions = (


### PR DESCRIPTION
fixed cases:
Liquidity assets - Display a price warning when exactly one position in the list contains a token without a price.

position list item - don't show price warning for token with liquidity equal to 0