### PR TITLE
Swap layout fix

### DIFF
--- a/src/components/Inputs/ExchangeAmountInput/style.ts
+++ b/src/components/Inputs/ExchangeAmountInput/style.ts
@@ -5,7 +5,8 @@ import { makeStyles } from 'tss-react/mui'
 export const useStyles = makeStyles()((theme: Theme) => ({
   root: {
     background: colors.invariant.newDark,
-    borderRadius: 20
+    borderRadius: 20,
+    width: '100%'
   },
   amountInput: {
     background: colors.invariant.newDark,
@@ -13,6 +14,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     borderRadius: 20,
     ...typography.heading2,
     width: '100%',
+    maxWidth: 200,
     textAlign: 'right',
     transition: 'all .3s',
     '& ::placeholder': {
@@ -119,6 +121,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     height: 65,
     padding: `10px 15px 0 15px `,
     display: 'flex',
+    width: '100%',
     justifyContent: 'space-between',
     alignItems: 'center'
   },

--- a/src/components/Swap/style.ts
+++ b/src/components/Swap/style.ts
@@ -304,7 +304,11 @@ export const useStyles = makeStyles()((theme: Theme) => ({
   },
 
   exchangeRoot: {
+    width: '100%',
     position: 'relative',
+    display: 'flex',
+    flexShrink: 1,
+    justifyContent: 'space-between',
     background: colors.invariant.newDark,
     borderRadius: 20
   },
@@ -496,6 +500,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     position: 'relative'
   },
   mobileChangeWrapper: {
+    width: '100%',
     display: 'flex',
     flexDirection: 'column',
     [theme.breakpoints.down('sm')]: {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fd88373d-36b1-4220-b2ad-6bde4998285c)
Reproduction:
Take unverfied without ticker, type 2222222222222