### PR TITLE
[530] fix overview layout

### DIFF
--- a/src/components/Portfolio/Overview/HeaderSection/style.ts
+++ b/src/components/Portfolio/Overview/HeaderSection/style.ts
@@ -22,7 +22,11 @@ export const useStyles = makeStyles()((_theme: Theme) => ({
   },
   headerText: {
     ...typography.heading2,
-    color: colors.invariant.text
+    color: colors.invariant.text,
+
+    [theme.breakpoints.down('sm')]: {
+      ...typography.heading3
+    }
   },
   warning: {
     marginLeft: '8px'


### PR DESCRIPTION
case for wallet: ATuknQhKuySnp8sCV6kAn1mdBraLKwMq24cGU8rF2xEW

The reported bug was about position item, but it looks like fixed.  
only the overview header was changed in this pr 
<img width="389" height="563" alt="image" src="https://github.com/user-attachments/assets/3f80acb3-4735-4609-9328-4c488432d816" />
